### PR TITLE
Added Single Docker File for Python

### DIFF
--- a/docker/dockerfiles/Dockerfile_all_py
+++ b/docker/dockerfiles/Dockerfile_all_py
@@ -9,7 +9,8 @@ RUN apt-get install -y python3
 RUN apt-get install -y python3-pip
 RUN apt-get install -y git
 RUN apt-get install -y graphviz
-RUN pip3 install -r uml/requirements.txt
+RUN pip3 install -r astroid==3.0.3 dill==0.3.8 gitdb==4.0.11 GitPython==3.1.42 isort==5.13.2 lint==1.2.1 mccabe==0.7.0 platformdirs==4.2.0 pylint==3.0.3 smmap==5.0.1 tomlkit==0.12.3
+
 
 #code Coverage
 RUN apt-get install -y \
@@ -23,7 +24,6 @@ RUN apt-get install -y \
     && pip install requests\
     && pip install coverage\
     && pip install pytest
-
 
 #dependency_checker
 


### PR DESCRIPTION
Directory docker/dockerfiles/Dockerfile_all_py
**YOU HAVE TO BE IN ROOT DIRECTORY TO RUN DOCKER FILE AS PYTHON NEEDS TO BE COPIED, CAN ONLY BE DONE BY BEING IN ROOT DIRECTORY**
- To run cd to root (TO50CS305/) 
 - docker build -t docker_python -f ./docker/dockerfiles/Dockerfile_all_py .